### PR TITLE
IMGUI_DISABLE_OBSOLETE_FUNCTIONS

### DIFF
--- a/Urho3D_imgui/Urho3D_imgui/imgui.cpp
+++ b/Urho3D_imgui/Urho3D_imgui/imgui.cpp
@@ -44,7 +44,6 @@ namespace Urho3D
 		io.KeyMap[ImGuiKey_Z] = SCANCODE_Z;
 
 		// setup callback functions
-		io.RenderDrawListsFn = ImGui_Impl_RenderDrawLists;
 		io.SetClipboardTextFn = SetClipboardText;
 		io.GetClipboardTextFn = GetClipboardText;
 
@@ -151,6 +150,7 @@ namespace Urho3D
 		// Render after Urho's main renderer has rendered
 		URHO3D_PROFILE(ImGuiRender);
 		ImGui::Render();
+		ImGui_Impl_RenderDrawLists(ImGui::GetDrawData());
 	}
 
 


### PR DESCRIPTION
Changes to allow Urho3D_imgui to work with IMGUI_DISABLE_OBSOLETE_FUNCTIONS defined.